### PR TITLE
Fix smart cursor and mod config narration issues

### DIFF
--- a/Mods/TerrariaAccess/Common/Systems/GamepadEmulation/DpadVirtualizationSystem.cs
+++ b/Mods/TerrariaAccess/Common/Systems/GamepadEmulation/DpadVirtualizationSystem.cs
@@ -87,7 +87,7 @@ public sealed class DpadVirtualizationSystem : ModSystem
         // D-pad virtualization uses different keys based on Smart Cursor state:
         // - Smart Cursor OFF: OKLS keys act as D-pad (arrow keys act as analog stick)
         // - Smart Cursor ON: Arrow keys act as D-pad (OKLS keys act as analog stick)
-        bool smartCursorActive = Main.SmartCursorIsUsed || Main.SmartCursorWanted;
+        bool smartCursorActive = GetEffectiveSmartCursorState();
 
         Vector2 nudges = Vector2.Zero;
         bool up, right, down, left;
@@ -159,7 +159,12 @@ public sealed class DpadVirtualizationSystem : ModSystem
 
     private static bool IsPressed(ModKeybind? keybind)
     {
-        return keybind?.Current ?? false;
+        if (keybind is null)
+        {
+            return false;
+        }
+
+        return keybind.Current || VirtualTriggerService.IsKeybindPressedRaw(keybind);
     }
 
     private static void ApplyDpadStyleSnap(Vector2 nudges)
@@ -169,6 +174,8 @@ public sealed class DpadVirtualizationSystem : ModSystem
             return;
         }
 
+        // Keep both cursor wanted flags disabled while D-pad tile nudging is active.
+        Main.SmartCursorWanted_Mouse = false;
         Main.SmartCursorWanted_GamePad = false;
         Matrix zoomMatrix = Main.GameViewMatrix.ZoomMatrix;
         Matrix inverseZoom = Matrix.Invert(zoomMatrix);
@@ -198,7 +205,7 @@ public sealed class DpadVirtualizationSystem : ModSystem
         PlayerInput.MouseY = clampedY;
         Main.mouseX = clampedX;
         Main.mouseY = clampedY;
-        PlayerInput.SettingsForUI.SetCursorMode(CursorMode.Gamepad);
+        PlayerInput.SettingsForUI.SetCursorMode(CursorMode.Mouse);
     }
 
     /// <summary>
@@ -219,7 +226,7 @@ public sealed class DpadVirtualizationSystem : ModSystem
         // D-pad keys vary based on Smart Cursor state:
         // - Smart Cursor OFF: OKLS keys act as D-pad
         // - Smart Cursor ON: Arrow keys act as D-pad
-        bool smartCursorActive = Main.SmartCursorIsUsed || Main.SmartCursorWanted;
+        bool smartCursorActive = GetEffectiveSmartCursorState();
 
         if (smartCursorActive)
         {
@@ -346,5 +353,20 @@ public sealed class DpadVirtualizationSystem : ModSystem
     {
         var buildModePlayer = Main.LocalPlayer?.GetModPlayer<BuildModePlayer>();
         return buildModePlayer?.IsBuildModeActive ?? false;
+    }
+
+    private static bool GetEffectiveSmartCursorState()
+    {
+        bool smartCursorActive;
+        if (GamepadEmulationSystem.TryGetForcedSmartCursorState(out bool forcedState))
+        {
+            smartCursorActive = forcedState;
+        }
+        else
+        {
+            smartCursorActive = Main.SmartCursorIsUsed || Main.SmartCursorWanted;
+        }
+
+        return smartCursorActive;
     }
 }

--- a/Mods/TerrariaAccess/Common/Systems/GamepadEmulation/VirtualStickService.cs
+++ b/Mods/TerrariaAccess/Common/Systems/GamepadEmulation/VirtualStickService.cs
@@ -49,7 +49,7 @@ internal static class VirtualStickService
         // When Smart Cursor is off, right stick keys (OKLS) are used for cursor nudge instead.
         // Arrow keys behave inversely: analog stick when Smart Cursor is off, D-pad when on.
         // In menu contexts, OKLS should always act as right stick for scrolling.
-        bool smartCursorActive = Main.SmartCursorIsUsed || Main.SmartCursorWanted;
+        bool smartCursorActive = GetEffectiveSmartCursorState();
         bool inMenuContext = Main.gameMenu || InputStateHelper.IsFancyUiActive();
         // Suppress right stick letter keys (O, K, L) when first letter navigation is active,
         // so those keys are reserved for item searching instead of injecting stick input.
@@ -96,7 +96,8 @@ internal static class VirtualStickService
 
         if (movementOverride || aimOverride || state.IsKeyDown(Keys.Space) || Main.mouseLeft || Main.mouseRight)
         {
-            PlayerInput.SettingsForUI.SetCursorMode(CursorMode.Gamepad);
+            bool inUiContext = Main.playerInventory || Main.gameMenu || InputStateHelper.IsFancyUiActive();
+            PlayerInput.SettingsForUI.SetCursorMode(inUiContext ? CursorMode.Gamepad : CursorMode.Mouse);
         }
     }
 
@@ -221,5 +222,20 @@ internal static class VirtualStickService
     {
         PlayerInput.GamepadThumbstickLeft = Vector2.Zero;
         PlayerInput.GamepadThumbstickRight = Vector2.Zero;
+    }
+
+    private static bool GetEffectiveSmartCursorState()
+    {
+        bool smartCursorActive;
+        if (GamepadEmulationSystem.TryGetForcedSmartCursorState(out bool forcedState))
+        {
+            smartCursorActive = forcedState;
+        }
+        else
+        {
+            smartCursorActive = Main.SmartCursorIsUsed || Main.SmartCursorWanted;
+        }
+
+        return smartCursorActive;
     }
 }

--- a/Mods/TerrariaAccess/Common/Systems/GamepadEmulationSystem.cs
+++ b/Mods/TerrariaAccess/Common/Systems/GamepadEmulationSystem.cs
@@ -53,6 +53,9 @@ public sealed class GamepadEmulationSystem : ModSystem
     private static Hook? _shiftInUseHook;
 
     private static HousingQueryHandler? _housingQueryHandler;
+    private static bool _smartCursorBindingWasPressed;
+    private static bool _smartCursorDesiredEnabled;
+    private static bool _smartCursorDesiredInitialized;
 
 
     public override void Load()
@@ -106,6 +109,8 @@ public sealed class GamepadEmulationSystem : ModSystem
 
         _housingQueryHandler = null;
         _mainMenuSelectWasPressed = false;
+        _smartCursorBindingWasPressed = false;
+        _smartCursorDesiredInitialized = false;
         VirtualTriggerService.ResetState();
     }
 
@@ -244,12 +249,39 @@ public sealed class GamepadEmulationSystem : ModSystem
 
     private static bool OverrideUsingGamepad(UsingGamepadGetter orig)
     {
-        return orig() || InputStateHelper.ShouldEmulateGamepad();
+        return orig() || ShouldExposeGamepadFlag(forceUi: false);
     }
 
     private static bool OverrideUsingGamepadUi(UsingGamepadGetter orig)
     {
-        return orig() || InputStateHelper.ShouldEmulateGamepad();
+        return orig() || ShouldExposeGamepadFlag(forceUi: true);
+    }
+
+    private static bool ShouldExposeGamepadFlag(bool forceUi)
+    {
+        if (!GamepadEmulationState.Enabled || InputStateHelper.IsTextInputActive())
+        {
+            return false;
+        }
+
+        // Only report "using gamepad" in UI contexts where we intentionally emulate
+        // controller navigation. Keeping this true in-world causes other systems/mods
+        // to continuously force XBoxGamepad mode.
+        if (forceUi)
+        {
+            return InputStateHelper.NeedsGamepadUiMode();
+        }
+
+        return InputStateHelper.NeedsGamepadUiMode() || IsLockOnContextActive();
+    }
+
+    private static bool IsLockOnContextActive()
+    {
+        bool lockOnEnabled = LockOnHelper.Enabled;
+        bool lockOnKeyPressed = GamepadEmulationKeybinds.LockOn is { } lockOnKeybind &&
+            (lockOnKeybind.Current || VirtualTriggerService.IsKeybindPressedRaw(lockOnKeybind));
+
+        return lockOnEnabled || lockOnKeyPressed;
     }
 
     private static void InjectVirtualSticksIntoGamepadInput(ILContext il)
@@ -451,8 +483,12 @@ public sealed class GamepadEmulationSystem : ModSystem
 
         if (!GamepadEmulationState.Enabled)
         {
+            _smartCursorBindingWasPressed = false;
+            _smartCursorDesiredInitialized = false;
             return;
         }
+
+        HandleSmartCursorBinding();
 
         bool needsUiMode = InputStateHelper.NeedsGamepadUiMode();
         ForceGamepadUiModeIfNeeded(needsUiMode);
@@ -460,6 +496,38 @@ public sealed class GamepadEmulationSystem : ModSystem
         ApplyInventoryVirtualTriggers(needsUiMode);
         ApplyMenuNavigationVirtualTriggers(needsUiMode);
         ApplyMainMenuVirtualTriggers();
+    }
+
+    public override void PreUpdatePlayers()
+    {
+        if (Main.dedServ)
+        {
+            return;
+        }
+
+        if (!ShouldDriveSmartCursorState())
+        {
+            return;
+        }
+
+        EnsureSmartCursorDesiredStateInitialized();
+        ApplySmartCursorWantedState(_smartCursorDesiredEnabled);
+    }
+
+    public override void PostUpdateEverything()
+    {
+        if (Main.dedServ)
+        {
+            return;
+        }
+
+        if (!ShouldDriveSmartCursorState())
+        {
+            return;
+        }
+
+        EnsureSmartCursorDesiredStateInitialized();
+        ApplySmartCursorWantedState(_smartCursorDesiredEnabled);
     }
 
     private static void ForceGamepadUiModeIfNeeded(bool needsUiMode)
@@ -479,7 +547,20 @@ public sealed class GamepadEmulationSystem : ModSystem
 
         if (GamepadEmulationState.Enabled)
         {
-            PlayerInput.CurrentInputMode = InputMode.XBoxGamepad;
+            if (IsLockOnContextActive())
+            {
+                // LockOn toggle path expects gamepad world mode in vanilla.
+                // Keep world gamepad mode only while lock-on context is active so TAB remains
+                // toggle-based instead of hold-to-aim.
+                PlayerInput.CurrentInputMode = InputMode.XBoxGamepad;
+                return;
+            }
+
+            // Keep gameplay input mode as keyboard. Forcing XBoxGamepad in-world can cause
+            // SmartCursor to follow the GamePad wanted flag path, which some mod stacks
+            // may continuously set and effectively lock SmartCursor on.
+            PlayerInput.CurrentInputMode = InputMode.Keyboard;
+            PlayerInput.SettingsForUI.SetCursorMode(CursorMode.Mouse);
         }
     }
 
@@ -514,6 +595,159 @@ public sealed class GamepadEmulationSystem : ModSystem
         {
             VirtualTriggerService.InjectFromKeybind(GamepadEmulationKeybinds.SmartSelect, TriggerNames.SmartSelect);
         }
+
+    }
+
+    private static void HandleSmartCursorBinding()
+    {
+        if (InputStateHelper.IsTextInputActive())
+        {
+            _smartCursorBindingWasPressed = false;
+            return;
+        }
+
+        bool smartCursorPressed = IsSmartCursorBindingPressedRaw();
+
+        if (smartCursorPressed)
+        {
+            VirtualTriggerService.InjectFromState("SmartCursor", isHeld: true);
+        }
+
+        ApplySmartCursorStateFromBinding(smartCursorPressed);
+    }
+
+    private static void ApplySmartCursorStateFromBinding(bool smartCursorPressed)
+    {
+        EnsureSmartCursorDesiredStateInitialized();
+        bool previousDesired = _smartCursorDesiredEnabled;
+
+        // Toggle mode: one key press flips between enabled/disabled.
+        if (Main.cSmartCursorModeIsToggleAndNotHold)
+        {
+            if (smartCursorPressed && !_smartCursorBindingWasPressed)
+            {
+                _smartCursorDesiredEnabled = !_smartCursorDesiredEnabled;
+            }
+        }
+        else
+        {
+            // Hold mode: key down enables smart cursor, key up disables it.
+            _smartCursorDesiredEnabled = smartCursorPressed;
+        }
+
+        ApplySmartCursorWantedState(_smartCursorDesiredEnabled);
+        _smartCursorBindingWasPressed = smartCursorPressed;
+    }
+
+    private static void EnsureSmartCursorDesiredStateInitialized()
+    {
+        if (_smartCursorDesiredInitialized)
+        {
+            return;
+        }
+
+        _smartCursorDesiredEnabled = Main.SmartCursorIsUsed || Main.SmartCursorWanted;
+        _smartCursorDesiredInitialized = true;
+    }
+
+    private static bool IsSmartCursorBindingPressedRaw()
+    {
+        return IsVanillaTriggerPressedRaw("SmartCursor");
+    }
+
+    private static void ApplySmartCursorWantedState(bool enabled)
+    {
+        Main.SmartCursorWanted_Mouse = enabled;
+        Main.SmartCursorWanted_GamePad = enabled;
+    }
+
+    private static bool ShouldDriveSmartCursorState()
+    {
+        if (!GamepadEmulationState.Enabled)
+        {
+            return false;
+        }
+
+        if (Main.gameMenu || InputStateHelper.IsTextInputActive())
+        {
+            return false;
+        }
+
+        Player? player = Main.LocalPlayer;
+        if (player is null || !player.active || player.dead || player.ghost)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryGetForcedSmartCursorState(out bool enabled)
+    {
+        if (!GamepadEmulationState.Enabled || !_smartCursorDesiredInitialized)
+        {
+            enabled = false;
+            return false;
+        }
+
+        enabled = _smartCursorDesiredEnabled;
+        return true;
+    }
+
+    private static bool IsVanillaTriggerPressedRaw(string triggerName)
+    {
+        PlayerInputProfile? profile = PlayerInput.CurrentProfile;
+        if (profile is null)
+        {
+            return false;
+        }
+
+        return IsVanillaTriggerPressedRaw(profile, InputMode.Keyboard, triggerName) ||
+               IsVanillaTriggerPressedRaw(profile, InputMode.KeyboardUI, triggerName);
+    }
+
+    private static bool IsVanillaTriggerPressedRaw(PlayerInputProfile profile, InputMode mode, string triggerName)
+    {
+        if (!profile.InputModes.TryGetValue(mode, out KeyConfiguration? config))
+        {
+            return false;
+        }
+
+        if (!config.KeyStatus.TryGetValue(triggerName, out List<string>? assignments) || assignments is null)
+        {
+            return false;
+        }
+
+        KeyboardState keyState = Main.keyState;
+        foreach (string assignment in assignments)
+        {
+            if (string.IsNullOrWhiteSpace(assignment))
+            {
+                continue;
+            }
+
+            if (TryIsMouseBindingPressed(assignment))
+            {
+                return true;
+            }
+
+            if (Enum.TryParse(assignment, ignoreCase: true, out Keys key) && keyState.IsKeyDown(key))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryIsMouseBindingPressed(string assignment)
+    {
+        return assignment switch
+        {
+            "Mouse1" => Main.mouseLeft,
+            "Mouse2" => Main.mouseRight,
+            _ => false,
+        };
     }
 
     private static void ApplyInventoryVirtualTriggers(bool inventoryUiActive)
@@ -718,6 +952,8 @@ public sealed class GamepadEmulationSystem : ModSystem
         {
             PlayerInput.SettingsForUI.TryRevertingToMouseMode();
             VirtualStickService.ResetState();
+            _smartCursorBindingWasPressed = false;
+            _smartCursorDesiredInitialized = false;
         }
 
         // Save the state to config for persistence

--- a/Mods/TerrariaAccess/Common/Systems/InGameNarration/InGameNarrationSystem.SmartCursorNarrator.cs
+++ b/Mods/TerrariaAccess/Common/Systems/InGameNarration/InGameNarrationSystem.SmartCursorNarrator.cs
@@ -69,23 +69,23 @@ public sealed partial class InGameNarrationSystem
 
             bool hasInteract = Main.HasSmartInteractTarget;
             bool hasSmartCursor = Main.SmartCursorIsUsed || Main.SmartCursorWanted;
+            string? modeChangeAnnouncement = null;
 
             if (_lastSmartCursorEnabled != hasSmartCursor)
             {
-                // Use the speech service's prefix queue to bundle mode change with next announcement
+                // Announce mode changes immediately instead of relying on pending-prefix chaining.
+                // In heavily modded setups, the follow-up cursor narration can be skipped.
                 if (hasSmartCursor)
                 {
-                    string smartCursorPrefix = LocalizationHelper.GetTextOrFallback(
+                    modeChangeAnnouncement = LocalizationHelper.GetTextOrFallback(
                         "Mods.TerrariaAccess.SmartCursor.Enabled",
                         "Smart cursor");
-                    ScreenReaderService.SetPendingPrefix(smartCursorPrefix);
                 }
                 else
                 {
-                    string unlockPrefix = LocalizationHelper.GetTextOrFallback(
+                    modeChangeAnnouncement = LocalizationHelper.GetTextOrFallback(
                         "Mods.TerrariaAccess.SmartCursor.UnlockedCursor",
                         "Unlocked cursor");
-                    ScreenReaderService.SetPendingPrefix(unlockPrefix);
                 }
 
                 ResetStateTracking();
@@ -118,7 +118,16 @@ public sealed partial class InGameNarrationSystem
             string? message = hasInteract ? DescribeSmartInteract(out category) : DescribeSmartCursor(player, out category);
             if (string.IsNullOrWhiteSpace(message))
             {
+                if (!string.IsNullOrWhiteSpace(modeChangeAnnouncement))
+                {
+                    ScreenReaderService.Announce(modeChangeAnnouncement, category: AnnouncementCategory.Tile, force: true);
+                }
                 return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(modeChangeAnnouncement))
+            {
+                message = $"{modeChangeAnnouncement}, {message}";
             }
 
             // Skip duplicate suppression when holding an axe so the player hears each tree announced

--- a/Mods/TerrariaAccess/Common/Systems/MenuNarration/ModConfig/ConfigElementDescriber.cs
+++ b/Mods/TerrariaAccess/Common/Systems/MenuNarration/ModConfig/ConfigElementDescriber.cs
@@ -61,7 +61,7 @@ internal static class ConfigElementDescriber
             if (!string.IsNullOrWhiteSpace(buttonText))
             {
                 string cleanButtonText = TextSanitizer.Clean(buttonText);
-                return $"{cleanButtonText} button";
+                return cleanButtonText;
             }
         }
 
@@ -72,10 +72,12 @@ internal static class ConfigElementDescriber
 
         // Try to get value
         string value = TryExtractConfigValue(element, accessors);
+        string tooltip = TryExtractTooltip(element, accessors);
 
         // Clean up the label and value
         string cleanLabel = !string.IsNullOrWhiteSpace(label) ? TextSanitizer.Clean(label) : string.Empty;
         string cleanValue = !string.IsNullOrWhiteSpace(value) ? TextSanitizer.Clean(value) : string.Empty;
+        string cleanTooltip = !string.IsNullOrWhiteSpace(tooltip) ? TextSanitizer.Clean(tooltip) : string.Empty;
 
         // For slider elements, replace raw value with percentage from Proportion
         if (accessors.ProportionProperty is not null && accessors.ProportionProperty.CanRead)
@@ -85,17 +87,20 @@ internal static class ConfigElementDescriber
                 if (accessors.ProportionProperty.GetValue(element) is float proportion)
                 {
                     string percentStr = $"{MathF.Round(proportion * 100f):0} percent";
+                    string description;
 
                     if (cleanLabel.Contains(':'))
                     {
                         int colonIndex = cleanLabel.IndexOf(':');
                         string labelPart = cleanLabel[..colonIndex];
-                        return $"{labelPart}: {percentStr}";
+                        description = $"{labelPart}: {percentStr}";
+                        return AppendTooltip(description, cleanTooltip);
                     }
 
-                    return !string.IsNullOrWhiteSpace(cleanLabel)
+                    description = !string.IsNullOrWhiteSpace(cleanLabel)
                         ? $"{cleanLabel}: {percentStr}"
                         : percentStr;
+                    return AppendTooltip(description, cleanTooltip);
                 }
             }
             catch
@@ -119,11 +124,11 @@ internal static class ConfigElementDescriber
         {
             if (labelAlreadyHasValue || labelEndsWithValue || valueContainsLabel || string.IsNullOrWhiteSpace(cleanValue))
             {
-                return cleanLabel;
+                return AppendTooltip(cleanLabel, cleanTooltip);
             }
             else
             {
-                return $"{cleanLabel}: {cleanValue}";
+                return AppendTooltip($"{cleanLabel}: {cleanValue}", cleanTooltip);
             }
         }
 
@@ -131,10 +136,10 @@ internal static class ConfigElementDescriber
         string extracted = ExtractElementText(element);
         if (!string.IsNullOrWhiteSpace(extracted))
         {
-            return TextSanitizer.Clean(extracted);
+            return AppendTooltip(TextSanitizer.Clean(extracted), cleanTooltip);
         }
 
-        return type.Name;
+        return AppendTooltip(type.Name, cleanTooltip);
     }
 
     /// <summary>
@@ -291,6 +296,21 @@ internal static class ConfigElementDescriber
         }
 
         return string.Empty;
+    }
+
+    private static string AppendTooltip(string description, string tooltip)
+    {
+        if (string.IsNullOrWhiteSpace(description) || string.IsNullOrWhiteSpace(tooltip))
+        {
+            return description;
+        }
+
+        if (description.Contains(tooltip, StringComparison.OrdinalIgnoreCase))
+        {
+            return description;
+        }
+
+        return $"{description}（{tooltip}）";
     }
 
     private static string FormatConfigValue(object? value)

--- a/Mods/TerrariaAccess/Common/Systems/MenuNarration/ModConfig/ModConfigEditHandler.cs
+++ b/Mods/TerrariaAccess/Common/Systems/MenuNarration/ModConfig/ModConfigEditHandler.cs
@@ -19,6 +19,8 @@ namespace TerrariaAccess.Common.Systems.MenuNarration.ModConfig;
 /// </summary>
 internal sealed class ModConfigEditHandler
 {
+    private static readonly FieldInfo? LastHoverField = typeof(UserInterface).GetField("_lastElementHover", BindingFlags.NonPublic | BindingFlags.Instance);
+
     private readonly AnnouncementGate _gate;
     private readonly SliderRepeatState _sliderState = new();
 
@@ -27,6 +29,7 @@ internal sealed class ModConfigEditHandler
     private List<UIElement>? _navigableElements;
     private int _configElementCount; // Excludes action buttons
     private int _skipInputFrames;
+    private UIElement? _lastHoveredElement;
 
     public ModConfigEditHandler(AnnouncementGate gate)
     {
@@ -48,6 +51,7 @@ internal sealed class ModConfigEditHandler
             _navigableElements = null;
             _configElementCount = 0;
             _skipInputFrames = 5; // Skip initial frames
+            _lastHoveredElement = null;
             _sliderState.Reset();
         }
 
@@ -98,6 +102,11 @@ internal sealed class ModConfigEditHandler
         {
             // Refresh action buttons (they may change)
             RefreshActionButtons(state);
+        }
+
+        if (!PlayerInput.UsingGamepadUI)
+        {
+            TryHandleMouseHover(isMenuContext, menuEventSink);
         }
 
         // Skip input during cooldown
@@ -181,6 +190,66 @@ internal sealed class ModConfigEditHandler
             AnnounceCurrentElement(isMenuContext, menuEventSink);
             SoundEngine.PlaySound(SoundID.MenuTick);
         }
+    }
+
+    private void TryHandleMouseHover(
+        bool isMenuContext,
+        Action<string, bool, MenuNarrationEventKind>? menuEventSink)
+    {
+        if (_navigableElements is null || _navigableElements.Count == 0)
+        {
+            _lastHoveredElement = null;
+            return;
+        }
+
+        UserInterface? activeUi = isMenuContext ? Main.MenuUI : Main.InGameUI;
+        UIElement? hovered = LastHoverField?.GetValue(activeUi) as UIElement;
+        UIElement? target = ResolveHoveredNarrationTarget(hovered);
+        if (target is null)
+        {
+            _lastHoveredElement = null;
+            return;
+        }
+
+        if (ReferenceEquals(target, _lastHoveredElement))
+        {
+            return;
+        }
+
+        int hoveredIndex = _navigableElements.FindIndex(element => ReferenceEquals(element, target));
+        if (hoveredIndex < 0)
+        {
+            _lastHoveredElement = null;
+            return;
+        }
+
+        _lastHoveredElement = target;
+        _currentElementIndex = hoveredIndex;
+        _sliderState.ClearElementTracking();
+        _gate.ClearFrameSuppression();
+        AnnounceCurrentElement(isMenuContext, menuEventSink);
+    }
+
+    private UIElement? ResolveHoveredNarrationTarget(UIElement? hovered)
+    {
+        if (hovered is null || _navigableElements is null)
+        {
+            return null;
+        }
+
+        UIElement? current = hovered;
+        while (current is not null)
+        {
+            UIElement? match = _navigableElements.FirstOrDefault(element => ReferenceEquals(element, current));
+            if (match is not null)
+            {
+                return match;
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
     }
 
     private void HandleAction(
@@ -546,6 +615,7 @@ internal sealed class ModConfigEditHandler
         _navigableElements = null;
         _configElementCount = 0;
         _skipInputFrames = 0;
+        _lastHoveredElement = null;
         _sliderState.Reset();
     }
 }

--- a/Mods/TerrariaAccess/Common/Utilities/TextSanitizer.cs
+++ b/Mods/TerrariaAccess/Common/Utilities/TextSanitizer.cs
@@ -105,6 +105,9 @@ internal static class TextSanitizer
         }
 
         if (token.StartsWith("i:", StringComparison.OrdinalIgnoreCase) ||
+            token.StartsWith("centeritem:", StringComparison.OrdinalIgnoreCase) ||
+            token.StartsWith("centertext:", StringComparison.OrdinalIgnoreCase) ||
+            token.StartsWith("centerimage:", StringComparison.OrdinalIgnoreCase) ||
             token.StartsWith("rb", StringComparison.OrdinalIgnoreCase) ||
             token.StartsWith("g", StringComparison.OrdinalIgnoreCase) ||
             token.StartsWith("wave", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Summary

Fix smart cursor, lock-on, and mod config narration issues.

## What changed

- Fixed smart cursor toggle/unlock behavior in keyboard mode, especially in heavily modded setups.
- Fixed `Tab` lock-on regressions caused by input mode handling.
- Fixed D-pad cursor navigation when smart cursor is unlocked.
- Improved smart cursor narration to follow the real effective state.
- Improved mod config narration in both in-game and Workshop config UIs.
- Merged config tooltip/help text into the main parameter announcement.
- Filtered raw formatting tags like `[centeritem:...]` from spoken text.
